### PR TITLE
🎨 Palette: Fix HUD button theming and add click feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-05-22 - Fixing Button Theming in PygameGUI **Learning:** `pygame_gui` themes using `element.class` require `object_id=ObjectID(class_id="class_name")`, not just `object_id="class_name"` (which sets the ID). Always verify theme selectors in `ui_theme.json`. **Action:** Use `ObjectID` for class-based styling.

--- a/src/yukkuri_game/game/ui/entity_info_panel.py
+++ b/src/yukkuri_game/game/ui/entity_info_panel.py
@@ -11,6 +11,7 @@ from pygame_gui.elements import (
     UIScrollingContainer,
     UIPanel,
 )
+from pygame_gui.core import ObjectID
 from .tabbed_panel import TabbedPanel
 
 
@@ -246,7 +247,7 @@ class EntityInfoPanel:
                 manager=self.manager,
                 container=self.window,
                 tool_tip_text="Sell selected entities",
-                object_id="sell_button",
+                object_id=ObjectID(class_id="sell_button"),
             )
             self.train_btn = UIButton(
                 relative_rect=pygame.Rect(10, y_pos + 50, 290, 40),
@@ -254,7 +255,7 @@ class EntityInfoPanel:
                 manager=self.manager,
                 container=self.window,
                 tool_tip_text="Train selected entities",
-                object_id="train_button",
+                object_id=ObjectID(class_id="train_button"),
             )
             self.punish_btn = UIButton(
                 relative_rect=pygame.Rect(10, y_pos + 100, 290, 40),
@@ -262,7 +263,7 @@ class EntityInfoPanel:
                 manager=self.manager,
                 container=self.window,
                 tool_tip_text="Punish selected entities",
-                object_id="punish_button",
+                object_id=ObjectID(class_id="punish_button"),
             )
         else:
             # Just Sell for items
@@ -272,7 +273,7 @@ class EntityInfoPanel:
                 manager=self.manager,
                 container=self.window,
                 tool_tip_text="Sell selected items",
-                object_id="sell_button",
+                object_id=ObjectID(class_id="sell_button"),
             )
 
     def update_stats(self, text: str) -> None:

--- a/src/yukkuri_game/game/ui/hud_events.py
+++ b/src/yukkuri_game/game/ui/hud_events.py
@@ -80,6 +80,11 @@ class HudEvents:
             "clean_btn": lambda: self.event_bus.publish(CleanToolRequestedEvent()),
         }
 
+    def _play_click(self) -> None:
+        """Plays the UI click sound."""
+        if self.audio_manager:
+            self.audio_manager.play_sound("click")
+
     def _save_game(self) -> None:
         """Publishes a SaveGameRequest."""
         # Default filename for UI-based save
@@ -139,16 +144,20 @@ class HudEvents:
                 hasattr(self.layout, attr_name)
                 and getattr(self.layout, attr_name) == ui_element
             ):
+                self._play_click()
                 handler()
                 return True
 
         if self._handle_settings_buttons(ui_element):
+            self._play_click()
             return True
 
         if self._handle_buy_buttons(ui_element):
+            self._play_click()
             return True
 
         if self._handle_selection_buttons(ui_element):
+            self._play_click()
             return True
 
         return False

--- a/src/yukkuri_game/game/ui/hud_layout.py
+++ b/src/yukkuri_game/game/ui/hud_layout.py
@@ -324,7 +324,7 @@ class HudLayout:
             manager=self.manager,
             container=self.bottom_panel,
             tool_tip_text="Remove waste and dirt from the ground",
-            object_id="clean_button",
+            object_id=ObjectID(class_id="clean_button"),
         )
 
     def create_selection_window(
@@ -459,6 +459,7 @@ class HudLayout:
             value_range=(0, 100),
             manager=self.manager,
             container=self.settings_window,
+            tool_tip_text="Adjust Master Volume",
         )
 
         # BGM Volume
@@ -474,6 +475,7 @@ class HudLayout:
             value_range=(0, 100),
             manager=self.manager,
             container=self.settings_window,
+            tool_tip_text="Adjust Background Music Volume",
         )
 
         # SFX Volume
@@ -489,6 +491,7 @@ class HudLayout:
             value_range=(0, 100),
             manager=self.manager,
             container=self.settings_window,
+            tool_tip_text="Adjust Sound Effects Volume",
         )
 
         # Window Settings
@@ -510,6 +513,7 @@ class HudLayout:
             relative_rect=pygame.Rect(130, 140, 200, 30),
             manager=self.manager,
             container=self.settings_window,
+            tool_tip_text="Change Window Resolution",
         )
 
         self.settings_controls["fullscreen_btn"] = UIButton(
@@ -517,6 +521,7 @@ class HudLayout:
             text="Fullscreen: ON" if fullscreen else "Fullscreen: OFF",
             manager=self.manager,
             container=self.settings_window,
+            tool_tip_text="Toggle Fullscreen Mode",
         )
         self.settings_controls["fullscreen_value"] = fullscreen
 


### PR DESCRIPTION
💡 **What:**
- Fixed theming for "Clean Tool", "Sell", "Train", and "Punish" buttons by correctly using `ObjectID(class_id=...)` instead of raw strings. This ensures they match the `ui_theme.json` selectors (e.g., `button.clean_button`).
- Added accessibility tooltips to Settings sliders (Master, BGM, SFX) and buttons.
- Added audio feedback ("click" sound) to all HUD button interactions.

🎯 **Why:**
- Buttons were not picking up their intended colors (Purple, Red, etc.) because of an ID vs Class mismatch in `pygame_gui`.
- Settings sliders lacked tooltips, making them less accessible.
- Buttons felt "dead" without auditory feedback.

📸 **Verify:**
- Run the game.
- Check that "Clean Tool" is purple, "Sell" is red, etc.
- Hover over Settings sliders to see tooltips.
- Click any HUD button and hear a click sound.

---
*PR created automatically by Jules for task [12457059398719486146](https://jules.google.com/task/12457059398719486146) started by @I-Have-No-Idea-What-IAmDoing*