### PR TITLE
🎨 Palette: Add Spacebar shortcut for Pause and fix UI feedback

### DIFF
--- a/src/yukkuri_game/engine/input_manager.py
+++ b/src/yukkuri_game/engine/input_manager.py
@@ -57,6 +57,7 @@ class InputManager:
                 "left": [pygame.K_LEFT, pygame.K_a],
                 "right": [pygame.K_RIGHT, pygame.K_d],
                 "pause": [pygame.K_ESCAPE],
+                "toggle_pause": [pygame.K_SPACE, pygame.K_p],
                 "interact": [pygame.K_z],
                 "debug_toggle": [pygame.K_F3],
                 "screenshot": [pygame.K_F12],

--- a/src/yukkuri_game/game/ui/hud_layout.py
+++ b/src/yukkuri_game/game/ui/hud_layout.py
@@ -175,7 +175,7 @@ class HudLayout:
             text="Pause",
             manager=self.manager,
             container=self.top_panel,
-            tool_tip_text="Pause/Resume the game",
+            tool_tip_text="Pause/Resume the game (Space)",
             object_id=ObjectID(class_id="control_button"),
         )
 

--- a/src/yukkuri_game/scenes/gameplay.py
+++ b/src/yukkuri_game/scenes/gameplay.py
@@ -31,6 +31,7 @@ from ..game.ai.navigation_service import NavigationService
 from ..game.camera import Camera
 from ..game.events import (
     CycleSpeedRequest,
+    GamePausedEvent,
     LoadGameRequest,
     ResolutionChangedEvent,
     SaveGameRequest,
@@ -300,6 +301,7 @@ class GameplayScene(Scene):
     def toggle_pause(self) -> None:
         """Toggles the pause state."""
         self.paused = not self.paused
+        self.event_bus.publish(GamePausedEvent(self.paused))
 
     def cycle_speed(self) -> None:
         """Cycles through game speed multipliers (1.0 -> 2.0 -> 5.0 -> 0.5)."""
@@ -526,6 +528,9 @@ class GameplayScene(Scene):
         self.ui_manager.process_events(event)
         # InputManager processing is handled by Application
         # Camera input is now handled by InputSystem via process_input()
+
+        if self.input_manager.is_action_just_pressed("toggle_pause"):
+            self.toggle_pause()
 
         if self.input_manager.is_action_just_pressed("pause"):
             # Update global state before leaving


### PR DESCRIPTION
Added a keyboard shortcut (Spacebar or P) for pausing the game. Fixed an issue where the Pause button text in the HUD would not update to "Resume" because the `GamePausedEvent` was not being published. Updated the UI tooltip to inform users of the new shortcut. This aligns with Palette's goal of improving accessibility and feedback.

---
*PR created automatically by Jules for task [5275012768281850400](https://jules.google.com/task/5275012768281850400) started by @I-Have-No-Idea-What-IAmDoing*