### PR TITLE
⚡ Bolt: Optimize ECS component fetching in loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -45,3 +45,11 @@
 ## 2026-10-31 - [ECS Query Iteration Optimization]
 **Learning:** `world.get_entities_with` does a `esper.get_components` query, extracts just the entity ID via a list comprehension, and discards the component references. The caller then typically iterates those entity IDs and calls `world.get_component(eid, ...)` inside a loop. `try_get_component` and `get_component` inside a loop is extremely slow in python compared to just iterating the components returned from `get_components_tuple`. Using `world.get_components_tuple(...)` is ~50x faster.
 **Action:** Never use `world.get_entities_with` followed by `world.get_component` in a loop. Always use `world.get_components_tuple` to retrieve the entity ID and all requested components in a single, fast iteration.
+
+## 2026-11-01 - [ECS Query Generator Reversal]
+**Learning:** `world.get_components_tuple()` returns a generator/iterator (via esper under the hood). If a system like `input_system` needs to iterate in reverse (e.g. for Z-order click detection), you must explicitly cast it to a list first (`reversed(list(components))`). Trying to call `reversed()` directly on a generator results in `TypeError: 'generator' object is not reversible`.
+**Action:** Always cast `get_components_tuple` results to a list before attempting reverse iteration or index-based access.
+
+## 2026-11-01 - [World Component Fetching Overreach]
+**Learning:** `world.try_get_component` and `world.get_component` have distinct semantics. `get_component` safely catches `KeyError` and returns `None` anyway. Needlessly changing `get_component` to `try_get_component` offers no actual performance benefit but risks introducing runtime crashes or test failures if mocks are misaligned.
+**Action:** Focus optimizations on bulk fetching (`get_components_tuple`). Avoid arbitrary swaps of single-fetch methods (`get_component` vs `try_get_component`) unless addressing a specific exception-handling bottleneck.

--- a/src/yukkuri_game/game/ai/behaviors/actions/searching.py
+++ b/src/yukkuri_game/game/ai/behaviors/actions/searching.py
@@ -360,22 +360,16 @@ class FindSocialTarget(Action):
         if ai.manual_override and ai.current_target_id != -1:
             return Status.SUCCESS
 
-        nearby_yukkuris = self.world.get_entities_with(YukkuriStats, Transform)
+        nearby_yukkuris = self.world.get_components_tuple(YukkuriStats, Transform)
 
         best_target = -1
         min_dist = float("inf")
 
-        for uid in nearby_yukkuris:
+        for uid, (u_stats, u_trans) in nearby_yukkuris:
             if uid == self.entity_id:
                 continue
 
             if uid in ai.failed_targets:
-                continue
-
-            u_stats = self.world.get_component(uid, YukkuriStats)
-            u_trans = self.world.get_component(uid, Transform)
-
-            if u_stats is None or u_trans is None:
                 continue
 
             is_compatible = u_stats.type_id == my_stats.type_id

--- a/src/yukkuri_game/game/input_system.py
+++ b/src/yukkuri_game/game/input_system.py
@@ -271,20 +271,12 @@ class InputSystem(System):
         """
         # Re-use hover logic to find top-most entity
         hover_radius = 32.0
-        entities = world.get_entities_with(Transform, Selectable)
-        entity_list = list(entities)
+        # Optimization: Use get_components_tuple to iterate efficiently
+        components = world.get_components_tuple(Transform, Selectable)
 
         target_id = -1
-        for ent in reversed(entity_list):
-            if isinstance(ent, tuple):
-                entity_id = ent[0]
-            else:
-                entity_id = ent
-
-            trans = world.get_component(entity_id, Transform)
-            if trans is None:
-                continue
-
+        # Reversed to match Z-order (assuming order in list follows creation/render order)
+        for entity_id, (trans, selectable) in reversed(list(components)):
             dist = ((trans.x - wx) ** 2 + (trans.y - wy) ** 2) ** 0.5
             if dist < hover_radius:
                 target_id = entity_id

--- a/src/yukkuri_game/game/services.py
+++ b/src/yukkuri_game/game/services.py
@@ -379,34 +379,42 @@ class GameService:
                 )
 
         sector_map = self.world.services.try_get(SectorMap)
-        candidate_items = []
 
         if sector_map:
             nearby_entities = sector_map.get_entities_in_radius(
                 position[0], position[1], max_radius
             )
 
-            for entity in nearby_entities:
-                if self.world.has_component(entity, ItemStats):
-                    candidate_items.append(entity)
+            for item in nearby_entities:
+                if item in exclude_ids:
+                    continue
+                istats = self.world.get_component(item, ItemStats)
+                itrans = self.world.get_component(item, Transform)
+                if istats and itrans and getattr(istats, stat_criteria, 0.0) > 0:
+                    d = math.hypot(itrans.x - position[0], itrans.y - position[1])
+
+                    if d > max_radius:
+                        continue
+
+                    if d < best_dist:
+                        best_dist = d
+                        best_item = item
         else:  # Fallback to linear scan.
-            candidate_items = self.world.get_entities_with(ItemStats, Transform)
-
-        for item in candidate_items:
-            if item in exclude_ids:
-                continue
-
-            istats = self.world.get_component(item, ItemStats)
-            itrans = self.world.get_component(item, Transform)
-            if istats and itrans and getattr(istats, stat_criteria, 0.0) > 0:
-                d = math.hypot(itrans.x - position[0], itrans.y - position[1])
-
-                if d > max_radius:
+            # Optimization: Use get_components_tuple to iterate efficiently
+            components = self.world.get_components_tuple(ItemStats, Transform)
+            for item, (istats, itrans) in components:
+                if item in exclude_ids:
                     continue
 
-                if d < best_dist:
-                    best_dist = d
-                    best_item = item
+                if getattr(istats, stat_criteria, 0.0) > 0:
+                    d = math.hypot(itrans.x - position[0], itrans.y - position[1])
+
+                    if d > max_radius:
+                        continue
+
+                    if d < best_dist:
+                        best_dist = d
+                        best_item = item
 
         return best_item
 

--- a/src/yukkuri_game/game/services.py
+++ b/src/yukkuri_game/game/services.py
@@ -389,8 +389,12 @@ class GameService:
                 if item in exclude_ids:
                     continue
                 istats = self.world.get_component(item, ItemStats)
+                if not istats:
+                    continue
                 itrans = self.world.get_component(item, Transform)
-                if istats and itrans and getattr(istats, stat_criteria, 0.0) > 0:
+                if not itrans:
+                    continue
+                if getattr(istats, stat_criteria, 0.0) > 0:
                     d = math.hypot(itrans.x - position[0], itrans.y - position[1])
 
                     if d > max_radius:

--- a/tests/core/test_services_coverage.py
+++ b/tests/core/test_services_coverage.py
@@ -224,8 +224,13 @@ class TestGameService:
         # Entity 2: Close, correct stat
         # Entity 3: Close, wrong stat
 
-        mock_world.get_entities_with.return_value = [1, 2, 3]
+        mock_world.get_components_tuple.return_value = [
+            (1, (MagicMock(nutrition=10), MagicMock(x=100, y=100))),
+            (2, (MagicMock(nutrition=10), MagicMock(x=10, y=10))),
+            (3, (MagicMock(nutrition=0), MagicMock(x=5, y=5))),
+        ]
 
+        # Keeping get_component side_effect just in case it's used elsewhere
         def get_component(e, c):
             if c == Transform:
                 if e == 1:
@@ -270,7 +275,7 @@ class TestGameService:
         item_pos = MagicMock(x=600, y=0)
         item_stats = MagicMock(nutrition=10)
 
-        mock_world.get_entities_with.return_value = [item_id]
+        mock_world.get_components_tuple.return_value = [(item_id, (item_stats, item_pos))]
 
         # Also need Personality for compatibility check in _update_opinion
         p_pers = MagicMock()


### PR DESCRIPTION
💡 What: Replaced slow O(N) iterative `get_component` queries with batched `get_components_tuple` fetching in multiple systems (`input_system.py`, `services.py`, `searching.py`). Also eliminated intermediary list creation when doing fallback linear scans.
🎯 Why: Iterating over `get_entities_with` and calling `get_component` inside a loop incurs significant function call overhead and dictionary lookups per entity per frame. `get_components_tuple` fetches the entities and all requested components simultaneously, which is ~50x faster.
📊 Impact: Expected to reduce frame time and tick time when handling large numbers of entities in input processing, item searching, and AI social targeting.
🔬 Measurement: Can be verified using performance benchmarks for high-entity scenes. Run `uv run pytest` to ensure behavior remains identical.

---
*PR created automatically by Jules for task [12393592607361358360](https://jules.google.com/task/12393592607361358360) started by @I-Have-No-Idea-What-IAmDoing*