### PR TITLE
Fix typing issues across test suite

### DIFF
--- a/tests/ai/test_interaction_logic.py
+++ b/tests/ai/test_interaction_logic.py
@@ -1,3 +1,4 @@
+from yukkuri_game.engine.types import EntityID
 
 import unittest
 import sys
@@ -31,11 +32,11 @@ class TestInteractionLogic(unittest.TestCase):
         """Test that the 'Talk' behavior generates an InteractionRequest with action='Talk'."""
         
         # 1. Setup Target (Friend)
-        friend_id = self.world.create_entity(
+        friend_id = EntityID(self.world.create_entity(
             YukkuriStats(type_id="reimu", name="Friend"),
             Transform(x=120, y=100) # 20px away (within interaction range)
-        )
-        self.ai.current_target_id = friend_id
+        ))
+        if self.ai: self.ai.current_target_id = friend_id
         
         # 2. Build Behavior Tree for "Talk"
         builder = build_standard_interaction_behavior("Talk")

--- a/tests/ai/test_predator_behavior.py
+++ b/tests/ai/test_predator_behavior.py
@@ -52,7 +52,8 @@ def test_find_prey(world, predator_entity, prey_entity):
     assert status == Status.SUCCESS
 
     ai = world.get_component(predator_entity, AIState)
-    assert getattr(ai, 'current_target_id', EntityID(-1)) == prey_entity
+    assert ai is not None
+    assert ai.current_target_id == prey_entity
 
 
 def test_find_prey_respects_range(world, predator_entity, prey_entity):

--- a/tests/ai/test_predator_behavior.py
+++ b/tests/ai/test_predator_behavior.py
@@ -1,3 +1,4 @@
+from yukkuri_game.engine.types import EntityID
 
 
 
@@ -51,7 +52,7 @@ def test_find_prey(world, predator_entity, prey_entity):
     assert status == Status.SUCCESS
 
     ai = world.get_component(predator_entity, AIState)
-    assert ai.current_target_id == prey_entity
+    assert getattr(ai, 'current_target_id', EntityID(-1)) == prey_entity
 
 
 def test_find_prey_respects_range(world, predator_entity, prey_entity):

--- a/tests/ai/test_utility_ai_regression.py
+++ b/tests/ai/test_utility_ai_regression.py
@@ -1,3 +1,5 @@
+from typing import cast
+from yukkuri_game.game.yukkuri_components import Predator, AIState
 """
 Regression tests for Utility AI bugs.
 These tests ensure previously fixed bugs don't reappear.
@@ -381,7 +383,7 @@ class TestDetectionRange:
         pred_comp = world.get_component(predator, Predator)
         
         nearby_enemies = 0
-        if dist <= pred_comp.prey_sense_radius:
+        if dist <= cast(Predator, pred_comp).prey_sense_radius:
             nearby_enemies = 1
             
         world.add_component(predator, Blackboard(nearby_enemies=nearby_enemies))
@@ -392,6 +394,6 @@ class TestDetectionRange:
         ai = world.get_component(predator, AIState)
         # Hunt action requires IsPredator and HasPrey thresholds to pass
         # If detection range is correctly using 500, the prey at 300 should be detected
-        assert ai.current_action == "Hunt", (
+        assert getattr(ai, 'current_action', None) == "Hunt", (
             "Predator with 500 sense radius should detect prey at 300 units"
         )

--- a/tests/ai/test_utility_ai_regression.py
+++ b/tests/ai/test_utility_ai_regression.py
@@ -394,6 +394,7 @@ class TestDetectionRange:
         ai = world.get_component(predator, AIState)
         # Hunt action requires IsPredator and HasPrey thresholds to pass
         # If detection range is correctly using 500, the prey at 300 should be detected
-        assert getattr(ai, 'current_action', None) == "Hunt", (
+        assert ai is not None
+        assert ai.current_action == "Hunt", (
             "Predator with 500 sense radius should detect prey at 300 units"
         )

--- a/tests/core/test_geometry_winding.py
+++ b/tests/core/test_geometry_winding.py
@@ -34,6 +34,13 @@ def calculate_signed_area(vertices):
 
 
 class MockTransform:
+    x: float
+    y: float
+    width: float
+    height: float
+    rotation: float
+    scale: float
+
     def __init__(self):
         self.x = 0
         self.y = 0

--- a/tests/engine/test_lazy_loader.py
+++ b/tests/engine/test_lazy_loader.py
@@ -16,7 +16,7 @@ def test_lazy_loader_access():
             return "value"
         return None
 
-    loader: LazyLoader[int] = LazyLoader(mock_loader, keys={"exists", "will_load"})
+    loader: LazyLoader[str] = LazyLoader(mock_loader, keys={"exists", "will_load"})
     
     # Should not have loaded yet
     assert len(loaded_keys) == 0
@@ -39,7 +39,7 @@ def test_lazy_loader_access():
         _ = loader["will_load"]
 
 def test_lazy_loader_setitem():
-    loader: LazyLoader[int] = LazyLoader(lambda k: None)
+    loader: LazyLoader[str] = LazyLoader(lambda k: None)
     loader["new"] = "data"
     
     assert loader["new"] == "data"

--- a/tests/engine/test_lazy_loader.py
+++ b/tests/engine/test_lazy_loader.py
@@ -16,7 +16,7 @@ def test_lazy_loader_access():
             return "value"
         return None
 
-    loader = LazyLoader(mock_loader, keys={"exists", "will_load"})
+    loader: LazyLoader[int] = LazyLoader(mock_loader, keys={"exists", "will_load"})
     
     # Should not have loaded yet
     assert len(loaded_keys) == 0
@@ -39,7 +39,7 @@ def test_lazy_loader_access():
         _ = loader["will_load"]
 
 def test_lazy_loader_setitem():
-    loader = LazyLoader(lambda k: None)
+    loader: LazyLoader[int] = LazyLoader(lambda k: None)
     loader["new"] = "data"
     
     assert loader["new"] == "data"

--- a/tests/engine/test_service_locator.py
+++ b/tests/engine/test_service_locator.py
@@ -58,8 +58,8 @@ def test_register_with_explicit_type() -> None:
 
     locator.register(service, service_type=CustomKey)
 
-    assert cast(Any, locator.get(CustomKey)) == service
-    assert cast(Any, locator.try_get(CustomKey)) == service
+    assert cast(Any, locator.get(CustomKey)) is service
+    assert cast(Any, locator.try_get(CustomKey)) is service
     assert locator.is_registered(CustomKey)
 
 

--- a/tests/engine/test_service_locator.py
+++ b/tests/engine/test_service_locator.py
@@ -1,3 +1,4 @@
+from typing import cast, Any
 """
 Tests for the ServiceLocator.
 """
@@ -57,8 +58,8 @@ def test_register_with_explicit_type() -> None:
 
     locator.register(service, service_type=CustomKey)
 
-    assert locator.get(CustomKey) is service
-    assert locator.try_get(CustomKey) is service
+    assert cast(Any, locator.get(CustomKey)) == service
+    assert cast(Any, locator.try_get(CustomKey)) == service
     assert locator.is_registered(CustomKey)
 
 

--- a/tests/game/systems/test_agility_integration.py
+++ b/tests/game/systems/test_agility_integration.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import MagicMock
-from src.yukkuri_game.engine.ecs import World
-from src.yukkuri_game.engine.types import EntityID
-from src.yukkuri_game.game.systems.perception_system import PerceptionSystem
-from src.yukkuri_game.game.systems.kinematic_movement_system import KinematicMovementSystem
-from src.yukkuri_game.game.yukkuri_components import AIState, Blackboard, YukkuriStats, TargetInfo
-from src.yukkuri_game.game.components import Transform, PhysicsBody, MovementController
+from yukkuri_game.engine.ecs import World
+from yukkuri_game.engine.types import EntityID
+from yukkuri_game.game.systems.perception_system import PerceptionSystem
+from yukkuri_game.game.systems.kinematic_movement_system import KinematicMovementSystem
+from yukkuri_game.game.yukkuri_components import AIState, Blackboard, YukkuriStats, TargetInfo
+from yukkuri_game.game.components import Transform, PhysicsBody, MovementController
 
 class TestAgilityIntegration:
     
@@ -49,7 +49,7 @@ class TestAgilityIntegration:
         blackboard = world.get_component(entity, Blackboard)
         
         # Mock TimeService
-        from src.yukkuri_game.game.services import TimeService
+        from yukkuri_game.game.services import TimeService
         time_service = MagicMock(spec=TimeService)
         time_service.time_elapsed = 0.0
         world.services.register(time_service, TimeService)
@@ -103,7 +103,7 @@ class TestAgilityIntegration:
         system.space = MagicMock() # Mock space
         
         # Fake FixedUpdate
-        from src.yukkuri_game.engine.events import PhysicsFixedUpdateEvent
+        from yukkuri_game.engine.events import PhysicsFixedUpdateEvent
         system.on_fixed_update(PhysicsFixedUpdateEvent(dt=0.1))
         
         # Verify allow call with agility


### PR DESCRIPTION
Addresses numerous `mypy` type errors detected across the project's testing suite, primarily focusing on `tests/ai/`, `tests/game/`, and `tests/engine/`. Fixed object assignments, casting, incorrect test definitions, and broken imports without compromising the functional integrity of the `pytest` test suite.

---
*PR created automatically by Jules for task [12708174275847064728](https://jules.google.com/task/12708174275847064728) started by @I-Have-No-Idea-What-IAmDoing*